### PR TITLE
fix: resolve config flow 'Invalid handler specified' error

### DIFF
--- a/custom_components/dyson_alt/__init__.py
+++ b/custom_components/dyson_alt/__init__.py
@@ -21,6 +21,9 @@ from .const import (
 from .coordinator import DysonDataUpdateCoordinator
 from .services import async_setup_services, async_remove_services
 
+# Import config flow to ensure it's available for registration
+from . import config_flow  # noqa: F401
+
 _LOGGER = logging.getLogger(__name__)
 
 # YAML Configuration Schema
@@ -46,8 +49,6 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS_MAP = {
     Platform.FAN: "fan",

--- a/custom_components/dyson_alt/manifest.json
+++ b/custom_components/dyson_alt/manifest.json
@@ -13,5 +13,5 @@
     "libdyson-rest==0.4.1",
     "libdyson-mqtt==0.2.1"
   ],
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-dyson-alt"
-version = "0.1.4"
+version = "0.1.5"
 description = "Unofficial alternative Home Assistant Dyson integration focusing on device capabilities and connection information"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
- Add explicit config flow import in __init__.py to ensure proper registration
- Remove duplicate logger declaration

This fixes the 'Invalid handler specified' error by ensuring Home Assistant can properly discover and register the config flow when the integration loads. The explicit import in __init__.py ensures the config flow module is loaded during integration initialization.