### PR TITLE
feat: enhance fault warning system with individual binary sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,19 @@ A comprehensive, production-ready Home Assistant integration for Dyson air purif
 ### **Binary Sensors**
 - **Connectivity** - Online/offline status
 - **Filter Replacement** - Alert when any filter needs changing
-- **Fault Detection** - Device error monitoring
+- **Individual Fault Sensors** - Dedicated sensors for each fault type:
+  - **Air Quality Sensor Fault** - AQS malfunction detection
+  - **Filter Fault** - General filter issues
+  - **HEPA Filter Fault** - HEPA filter specific problems
+  - **Carbon Filter Fault** - Carbon filter issues
+  - **Motor Fault** - Fan motor problems and stalls
+  - **Temperature Sensor Fault** - Temperature monitoring issues
+  - **Humidity Sensor Fault** - Humidity measurement problems
+  - **Power Supply Fault** - Electrical and power issues
+  - **WiFi Connection Fault** - Connectivity problems
+  - **System Fault** - General device malfunctions
+  - **Brush Fault** - Brush blockages and wear (vacuum models)
+  - **Dustbin Fault** - Bin full/missing alerts (vacuum models)
 
 ### **Controls**
 - **Speed Control** - Precise fan speed (1-10)

--- a/custom_components/dyson_alt/binary_sensor.py
+++ b/custom_components/dyson_alt/binary_sensor.py
@@ -3,20 +3,65 @@
 from __future__ import annotations
 
 import logging
+from typing import Dict, Any, Tuple, List
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, FAULT_TRANSLATIONS, DEVICE_CATEGORY_FAULT_CODES, CAPABILITY_FAULT_CODES
 from .coordinator import DysonDataUpdateCoordinator
 from .entity import DysonEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _is_fault_code_relevant(fault_code: str, device_category_str: Any, device_capabilities: List[Any]) -> bool:
+    """Check if a fault code is relevant for a device based on category and capabilities."""
+    # Convert device category to string if it's an enum object
+    if hasattr(device_category_str, "value"):
+        category_str = device_category_str.value
+    else:
+        category_str = str(device_category_str)
+
+    # Convert capabilities to string values if they are enum objects
+    capability_strings = []
+    for cap in device_capabilities:
+        if hasattr(cap, "value"):
+            capability_strings.append(cap.value)
+        else:
+            capability_strings.append(str(cap))
+
+    _LOGGER.debug(
+        "Checking fault code '%s' relevance - category: %s (%s), capabilities: %s",
+        fault_code,
+        device_category_str,
+        category_str,
+        capability_strings,
+    )
+
+    # Check if fault code is relevant for device category
+    category_fault_codes = DEVICE_CATEGORY_FAULT_CODES.get(category_str, [])
+    if fault_code in category_fault_codes:
+        _LOGGER.debug("Fault code '%s' matches device category '%s'", fault_code, category_str)
+        return True
+
+    # Check if fault code requires specific capabilities
+    for capability, fault_codes in CAPABILITY_FAULT_CODES.items():
+        if fault_code in fault_codes:
+            is_relevant = capability in capability_strings
+            _LOGGER.debug(
+                "Fault code '%s' requires capability '%s' - device has it: %s", fault_code, capability, is_relevant
+            )
+            return is_relevant
+
+    _LOGGER.debug("Fault code '%s' not relevant for this device", fault_code)
+    return False
 
 
 async def async_setup_entry(
@@ -35,6 +80,24 @@ async def async_setup_entry(
             DysonFilterReplacementSensor(coordinator),
         ]
     )
+
+    # Individual fault binary sensors - filter by device category and capabilities
+    device_category_str = coordinator.device_category
+    device_capabilities = coordinator.device_capabilities
+
+    _LOGGER.debug(
+        "Device category: %s, capabilities: %s",
+        device_category_str,
+        device_capabilities,
+    )
+
+    # Create fault sensors for all fault types that are relevant to this device
+    for fault_code, fault_info in FAULT_TRANSLATIONS.items():
+        if _is_fault_code_relevant(fault_code, device_category_str, device_capabilities):
+            entities.append(DysonFaultSensor(coordinator, fault_code, fault_info))
+            _LOGGER.debug("Adding fault sensor for code: %s", fault_code)
+        else:
+            _LOGGER.debug("Skipping fault sensor for irrelevant code: %s", fault_code)
 
     async_add_entities(entities, True)
 
@@ -64,3 +127,162 @@ class DysonFilterReplacementSensor(DysonEntity, BinarySensorEntity):  # type: ig
         else:
             self._attr_is_on = False
         super()._handle_coordinator_update()
+
+
+class DysonFaultSensor(DysonEntity, BinarySensorEntity):  # type: ignore[misc]
+    """Representation of a device fault status."""
+
+    coordinator: DysonDataUpdateCoordinator
+
+    def __init__(self, coordinator: DysonDataUpdateCoordinator, fault_code: str, fault_info: Dict[str, str]) -> None:
+        """Initialize the fault sensor."""
+        super().__init__(coordinator)
+        self._fault_code = fault_code
+        self._fault_info = fault_info
+        self._attr_unique_id = f"{coordinator.serial_number}_fault_{fault_code}"
+        self._attr_name = f"Fault {self._get_fault_friendly_name()}"
+        self._attr_device_class = BinarySensorDeviceClass.PROBLEM
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def _get_fault_friendly_name(self) -> str:
+        """Get a friendly name for the fault code."""
+        fault_names = {
+            "aqs": "Air Quality Sensor",
+            "fltr": "Filter",
+            "hflr": "HEPA Filter",
+            "cflr": "Carbon Filter",
+            "mflr": "Motor",
+            "temp": "Temperature Sensor",
+            "humi": "Humidity Sensor",
+            "pwr": "Power Supply",
+            "wifi": "WiFi Connection",
+            "sys": "System",
+            "brsh": "Brush",
+            "bin": "Dustbin",
+        }
+        return fault_names.get(self._fault_code, self._fault_code.upper())
+
+    def _get_fault_icon(self, is_fault: bool = False) -> str:
+        """Get an appropriate icon for the fault type based on state."""
+        if self._fault_code == "aqs":
+            # Air quality sensor: air-purifier when OK, air-purifier-off when fault
+            return "mdi:air-purifier-off" if is_fault else "mdi:air-purifier"
+
+        # Other fault types use static icons
+        fault_icons = {
+            "fltr": "mdi:air-filter",
+            "hflr": "mdi:air-filter",
+            "cflr": "mdi:air-filter",
+            "mflr": "mdi:fan-alert",
+            "temp": "mdi:thermometer-alert",
+            "humi": "mdi:water-alert",
+            "pwr": "mdi:power-plug-off",
+            "wifi": "mdi:wifi-off",
+            "sys": "mdi:alert-circle",
+            "brsh": "mdi:brush-variant",
+            "bin": "mdi:delete-alert",
+        }
+        return fault_icons.get(self._fault_code, "mdi:alert")
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon based on current sensor state."""
+        is_fault = self.is_on if self.is_on is not None else False
+        return self._get_fault_icon(is_fault=is_fault)
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if not self.coordinator.device:
+            self._attr_is_on = False
+            self._attr_extra_state_attributes = {}
+            super()._handle_coordinator_update()
+            return
+
+        # Check if this fault code is relevant to the current device category and capabilities
+        device_category_str = self.coordinator.device_category
+        device_capabilities = self.coordinator.device_capabilities
+
+        if not _is_fault_code_relevant(self._fault_code, device_category_str, device_capabilities):
+            # This fault sensor is not relevant to the current device type
+            self._attr_available = False
+            self._attr_is_on = False
+            self._attr_extra_state_attributes = {
+                "fault_code": self._fault_code,
+                "status": f"Not applicable to {device_category_str} devices",
+            }
+            super()._handle_coordinator_update()
+            return
+
+        # Make sure the sensor is available for relevant fault codes
+        self._attr_available = True
+
+        # Get current faults from device
+        try:
+            # We'll use the same method the coordinator uses
+            if hasattr(self.coordinator.device, "_faults_data") and self.coordinator.device._faults_data:
+                raw_faults = self.coordinator.device._faults_data
+                # Check if this fault code has any non-OK values in any section
+                fault_found, fault_value = self._search_fault_in_data(raw_faults)
+
+                if fault_found:
+                    # Only consider it a fault if it's not OK/NONE/PASS/GOOD
+                    if fault_value and fault_value.upper() not in ["OK", "NONE", "PASS", "GOOD"]:
+                        self._attr_is_on = True
+                        # Get human-readable description
+                        description = self._fault_info.get(fault_value, f"Unknown fault: {fault_value}")
+                        self._attr_extra_state_attributes = {
+                            "fault_code": self._fault_code,
+                            "fault_value": fault_value,
+                            "description": description,
+                            "severity": self._get_fault_severity(fault_value),
+                        }
+                    else:
+                        self._attr_is_on = False
+                        self._attr_extra_state_attributes = {
+                            "fault_code": self._fault_code,
+                            "fault_value": fault_value,
+                            "status": "OK",
+                        }
+                else:
+                    self._attr_is_on = False
+                    self._attr_extra_state_attributes = {
+                        "fault_code": self._fault_code,
+                        "status": "No data",
+                    }
+            else:
+                self._attr_is_on = False
+                self._attr_extra_state_attributes = {}
+
+        except Exception as err:
+            _LOGGER.warning("Error updating fault sensor %s: %s", self._fault_code, err)
+            self._attr_is_on = False
+            self._attr_extra_state_attributes = {}
+
+        super()._handle_coordinator_update()
+
+    def _search_fault_in_data(self, fault_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """Search for fault code in nested fault data structure."""
+        # Search in all fault sections
+        sections_to_search = ["product-errors", "product-warnings", "module-errors", "module-warnings"]
+
+        for section_name in sections_to_search:
+            section = fault_data.get(section_name, {})
+            if self._fault_code in section:
+                return True, section[self._fault_code]
+
+        # Also check top-level for simple fault structure
+        if self._fault_code in fault_data:
+            return True, fault_data[self._fault_code]
+
+        return False, ""
+
+    def _get_fault_severity(self, fault_value: str) -> str:
+        """Determine fault severity based on fault value."""
+        if fault_value.upper() in ["FAIL", "STLL"]:
+            return "Critical"
+        elif fault_value.upper() in ["WARN", "HIGH", "LOW", "WEAK"]:
+            return "Warning"
+        elif fault_value.upper() in ["CHNG", "FULL", "WORN"]:
+            return "Maintenance"
+        else:
+            return "Unknown"

--- a/custom_components/dyson_alt/const.py
+++ b/custom_components/dyson_alt/const.py
@@ -153,3 +153,137 @@ SERVICE_FETCH_ACCOUNT_DATA: Final = "fetch_account_data"
 
 # Event types
 EVENT_DEVICE_FAULT: Final = "dyson_device_fault"
+
+# Fault code translations
+# Based on Dyson device fault codes - only non-OK values represent actual faults
+FAULT_TRANSLATIONS: Final = {
+    # Air quality sensor faults
+    "aqs": {
+        "FAIL": "Air quality sensor failure",
+        "WARN": "Air quality sensor warning",
+        "OFF": "Air quality sensor disabled",
+    },
+    # Filter faults
+    "fltr": {
+        "FAIL": "Filter failure - replace filter",
+        "WARN": "Filter warning - low life remaining",
+        "CHNG": "Filter needs replacement",
+    },
+    # HEPA filter faults
+    "hflr": {
+        "FAIL": "HEPA filter failure",
+        "WARN": "HEPA filter warning - low life remaining",
+        "CHNG": "HEPA filter needs replacement",
+    },
+    # Carbon filter faults
+    "cflr": {
+        "FAIL": "Carbon filter failure",
+        "WARN": "Carbon filter warning - low life remaining",
+        "CHNG": "Carbon filter needs replacement",
+    },
+    # Motor faults
+    "mflr": {
+        "FAIL": "Motor failure - device malfunction",
+        "STLL": "Motor stall detected",
+        "WRNG": "Motor warning",
+    },
+    # Temperature sensor faults
+    "temp": {
+        "FAIL": "Temperature sensor failure",
+        "HIGH": "Temperature too high",
+        "LOW": "Temperature too low",
+    },
+    # Humidity sensor faults
+    "humi": {
+        "FAIL": "Humidity sensor failure",
+        "HIGH": "Humidity too high",
+        "LOW": "Humidity too low",
+    },
+    # Power supply faults
+    "pwr": {
+        "FAIL": "Power supply failure",
+        "VOLT": "Voltage fault detected",
+        "CURR": "Current fault detected",
+    },
+    # Communication faults
+    "wifi": {
+        "FAIL": "WiFi connection failure",
+        "WEAK": "WiFi signal weak",
+        "DISC": "WiFi disconnected",
+    },
+    # General system faults
+    "sys": {
+        "FAIL": "System failure - contact support",
+        "OVHT": "Device overheating",
+        "LBAT": "Low battery warning",
+    },
+    # Brush faults (for vacuum models)
+    "brsh": {
+        "FAIL": "Brush failure - check for blockages",
+        "STCK": "Brush stuck or blocked",
+        "WORN": "Brush worn - needs replacement",
+    },
+    # Bin/dustbin faults
+    "bin": {
+        "FULL": "Dustbin full - please empty",
+        "MISS": "Dustbin missing or not properly seated",
+        "BLCK": "Dustbin blocked",
+    },
+}
+
+# Device category to fault code mapping
+# Only create fault sensors for fault types relevant to each device category
+DEVICE_CATEGORY_FAULT_CODES: Final = {
+    # Environment Cleaner (fans with filters) - air purifiers/fans
+    DEVICE_CATEGORY_EC: [
+        "mflr",  # Motor/fan
+        "pwr",  # Power supply
+        "wifi",  # WiFi connection
+        "sys",  # System faults
+    ],
+    # Robot vacuum cleaners
+    DEVICE_CATEGORY_ROBOT: [
+        "mflr",  # Motor
+        "pwr",  # Power supply
+        "wifi",  # WiFi connection
+        "sys",  # System faults
+        "brsh",  # Brush system
+        "bin",  # Dustbin
+    ],
+    # Regular vacuum cleaners
+    DEVICE_CATEGORY_VACUUM: [
+        "mflr",  # Motor
+        "pwr",  # Power supply
+        "wifi",  # WiFi connection
+        "sys",  # System faults
+        "brsh",  # Brush system
+        "bin",  # Dustbin
+    ],
+    # Floor cleaner devices
+    DEVICE_CATEGORY_FLRC: [
+        "mflr",  # Motor
+        "pwr",  # Power supply
+        "wifi",  # WiFi connection
+        "sys",  # System faults
+        "brsh",  # Brush system
+        "bin",  # Tank/reservoir
+    ],
+}
+
+# Capability-based fault code filtering
+# These faults only appear if the device has specific capabilities
+CAPABILITY_FAULT_CODES: Final = {
+    "ExtendedAQ": [
+        "aqs",  # Air quality sensor
+        "fltr",  # General filter
+        "hflr",  # HEPA filter
+        "cflr",  # Carbon filter
+    ],
+    "EnvironmentalData": [
+        "temp",  # Temperature sensor
+    ],
+    # TODO: Identify humidifier capability name when we have a humidifier device
+    # "Humidifier": [
+    #     "humi",  # Humidity sensor
+    # ],
+}

--- a/custom_components/dyson_alt/sensor.py
+++ b/custom_components/dyson_alt/sensor.py
@@ -257,6 +257,7 @@ class DysonWiFiSensor(DysonEntity, SensorEntity):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "dBm"
         self._attr_icon = "mdi:wifi"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""


### PR DESCRIPTION
- Replace simple log warnings with dedicated fault binary sensors
- Implement device category and capability-based fault filtering
- Add dynamic icons for air quality sensor faults (mdi:air-purifier/mdi:air-purifier-off)
- Move fault sensors and WiFi signal to diagnostics category for better organization
- Support ExtendedAQ capability for air quality/filter sensors
- Support EnvironmentalData capability for temperature sensor
- Add comprehensive fault translations for user-friendly names
- Enhance coordinator capability extraction from nested API responses
- Filter fault sensors by device relevance (no vacuum sensors on air purifiers)
- Maintain backwards compatibility with existing fault logging

Fault sensors now appear in device diagnostics section and provide
clear visual feedback with appropriate icons and state information.