### PR TITLE
fix: resolve fan state sync and reduce aggressive MQTT polling

### DIFF
--- a/custom_components/dyson_alt/__init__.py
+++ b/custom_components/dyson_alt/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.helpers import config_validation as cv
 # Import config flow explicitly to ensure it's available for registration
 from .config_flow import DysonConfigFlow  # noqa: F401
 from .const import (
-    CONF_DISCOVERY_METHOD,
     CONF_SERIAL_NUMBER,
     DISCOVERY_CLOUD,
     DISCOVERY_STICKER,
@@ -180,17 +179,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                 if not existing_entries:
                     # Create individual config entry for this device
-                    device_data = {
-                        CONF_SERIAL_NUMBER: device_serial,
-                        CONF_DISCOVERY_METHOD: DISCOVERY_CLOUD,
-                        CONF_USERNAME: entry.data.get("email", ""),
-                        "auth_token": entry.data.get("auth_token"),
-                        # Do not set connection_type - let device use account default
-                        "device_name": device_info.get("name"),
-                        "product_type": device_info.get("product_type"),
-                        "category": device_info.get("category"),
-                        "parent_entry_id": entry.entry_id,  # Link back to account entry
-                    }
+                    from .device_utils import create_cloud_device_config
+
+                    device_data = create_cloud_device_config(
+                        serial_number=device_serial,
+                        username=entry.data.get("email", ""),
+                        device_info=device_info,
+                        auth_token=entry.data.get("auth_token"),
+                        parent_entry_id=entry.entry_id,
+                    )
 
                     _LOGGER.info("Creating individual config entry for device: %s", device_serial)
                     # Schedule device entry creation as a background task

--- a/custom_components/dyson_alt/button.py
+++ b/custom_components/dyson_alt/button.py
@@ -45,7 +45,7 @@ class DysonReconnectButton(DysonEntity, ButtonEntity):
         """Initialize the reconnect button."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_reconnect"
-        self._attr_name = "Reconnect"
+        self._attr_name = f"{coordinator.device_name} Reconnect"
         self._attr_icon = "mdi:wifi-sync"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 

--- a/custom_components/dyson_alt/climate.py
+++ b/custom_components/dyson_alt/climate.py
@@ -49,7 +49,7 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):  # type: ignore[misc]
         """Initialize the climate entity."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_climate"
-        self._attr_name = "Climate"
+        self._attr_name = f"{coordinator.device_name} Climate"
         self._attr_icon = "mdi:thermostat"
 
         # Climate features

--- a/custom_components/dyson_alt/config_flow.py
+++ b/custom_components/dyson_alt/config_flow.py
@@ -19,11 +19,7 @@ from .const import (
     CONF_SERIAL_NUMBER,
     CONF_CREDENTIAL,
     CONF_HOSTNAME,
-    CONF_DISCOVERY_METHOD,
-    CONF_CONNECTION_TYPE,
     CONF_MQTT_PREFIX,
-    CONNECTION_TYPE_LOCAL_ONLY,
-    DISCOVERY_MANUAL,
     DOMAIN,
     MDNS_SERVICE_DYSON,
 )
@@ -255,17 +251,17 @@ class DysonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 hostname = f"{serial_number}.local"
 
                         # Create the device entry with manual discovery method
-                        config_data = {
-                            CONF_SERIAL_NUMBER: serial_number,
-                            CONF_CREDENTIAL: credential,
-                            CONF_MQTT_PREFIX: mqtt_prefix,
-                            CONF_DISCOVERY_METHOD: DISCOVERY_MANUAL,
-                            CONF_CONNECTION_TYPE: CONNECTION_TYPE_LOCAL_ONLY,  # Default for manual setup
-                            "device_name": device_name,
-                            CONF_HOSTNAME: hostname,
-                            "device_category": device_category,
-                            "capabilities": capabilities,
-                        }
+                        from .device_utils import create_manual_device_config
+
+                        config_data = create_manual_device_config(
+                            serial_number=serial_number,
+                            credential=credential,
+                            mqtt_prefix=mqtt_prefix,
+                            device_name=device_name,
+                            hostname=hostname,
+                            device_category=device_category,
+                            capabilities=capabilities,
+                        )
 
                         _LOGGER.info("Creating manual device config entry for: %s", device_name)
                         return self.async_create_entry(

--- a/custom_components/dyson_alt/const.py
+++ b/custom_components/dyson_alt/const.py
@@ -8,7 +8,7 @@ DOMAIN: Final = "dyson_alt"
 # Default values
 DEFAULT_CLOUD_POLLING_INTERVAL: Final = 300  # 5 minutes in seconds
 DEFAULT_DEVICE_POLLING_INTERVAL: Final = (
-    60  # 60 seconds for device state updates (reduced from 30 to reduce MQTT stress)
+    300  # 5 minutes for connectivity checks only (devices send natural STATE-CHANGE messages)
 )
 DEFAULT_TIMEOUT: Final = 10  # 10 seconds for network operations
 
@@ -74,11 +74,11 @@ CAPABILITY_HUMIDIFIER: Final = "Humidifier"
 AVAILABLE_CAPABILITIES: Final = {
     CAPABILITY_ADVANCE_OSCILLATION: "Advanced Oscillation (precise angle control)",
     CAPABILITY_SCHEDULING: "Scheduling (timer and schedule controls)",
-    CAPABILITY_ENVIRONMENTAL_DATA: "Environmental Data (temperature, humidity sensors)",
+    CAPABILITY_ENVIRONMENTAL_DATA: "Environmental Data (meta-capability, no specific sensors created)",
     CAPABILITY_EXTENDED_AQ: "Extended Air Quality (PM2.5, PM10 sensors with continuous monitoring)",
-    CAPABILITY_HEATING: "Heating (heat mode and temperature control)",
+    CAPABILITY_HEATING: "Heating (heat mode, temperature control, and temperature sensors)",
     CAPABILITY_FORMALDEHYDE: "Formaldehyde Detection (carbon filter, HCHO sensor, VOC/NO2 sensors, continuous monitoring)",
-    CAPABILITY_HUMIDIFIER: "Humidifier (humidification controls and sensors)",
+    CAPABILITY_HUMIDIFIER: "Humidifier (humidification controls and humidity sensors)",
 }
 
 # MQTT topics

--- a/custom_components/dyson_alt/device_utils.py
+++ b/custom_components/dyson_alt/device_utils.py
@@ -1,0 +1,241 @@
+"""Utility functions for device configuration and setup."""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from homeassistant.const import CONF_USERNAME
+
+from .const import (
+    CONF_CREDENTIAL,
+    CONF_DISCOVERY_METHOD,
+    CONF_HOSTNAME,
+    CONF_MQTT_PREFIX,
+    CONF_SERIAL_NUMBER,
+    CONNECTION_TYPE_LOCAL_ONLY,
+    DISCOVERY_CLOUD,
+    DISCOVERY_MANUAL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def normalize_device_category(category: Any) -> List[str]:
+    """Normalize device category to a consistent list format.
+
+    Args:
+        category: Can be string, list, enum, or None
+
+    Returns:
+        List of category strings, defaults to ["ec"] if invalid
+    """
+    if category is None:
+        return ["ec"]
+
+    # Handle enum objects
+    if hasattr(category, "value"):
+        category = category.value
+    elif hasattr(category, "name"):
+        category = category.name.lower()
+
+    # Convert to list if string
+    if isinstance(category, str):
+        return [category]
+
+    # If already a list, ensure all items are strings
+    if isinstance(category, list):
+        return [str(item) for item in category if item]
+
+    # Fallback for any other type
+    _LOGGER.warning("Unknown category type %s, defaulting to ['ec']", type(category))
+    return ["ec"]
+
+
+def normalize_capabilities(capabilities: Any) -> List[str]:
+    """Normalize device capabilities to a consistent list format.
+
+    Args:
+        capabilities: Can be list, None, or other types
+
+    Returns:
+        List of capability strings, empty list if invalid
+    """
+    if capabilities is None:
+        return []
+
+    if isinstance(capabilities, list):
+        # Convert enum objects to their string values, otherwise use str()
+        result = []
+        for cap in capabilities:
+            if cap:  # Skip empty/None values
+                if hasattr(cap, "value"):
+                    result.append(cap.value)  # Use enum value
+                else:
+                    result.append(str(cap))  # Fallback to string conversion
+        return result
+
+    # Single capability as string
+    if isinstance(capabilities, str):
+        return [capabilities]
+
+    _LOGGER.warning("Unknown capabilities type %s, defaulting to []", type(capabilities))
+    return []
+
+
+def create_device_config_data(
+    serial_number: str,
+    discovery_method: str,
+    device_name: Optional[str] = None,
+    hostname: Optional[str] = None,
+    credential: Optional[str] = None,
+    mqtt_prefix: Optional[str] = None,
+    device_category: Optional[Any] = None,
+    capabilities: Optional[Any] = None,
+    connection_type: Optional[str] = None,
+    username: Optional[str] = None,
+    auth_token: Optional[str] = None,
+    product_type: Optional[str] = None,
+    category: Optional[str] = None,
+    parent_entry_id: Optional[str] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Create standardized device configuration data.
+
+    This consolidates the config data creation logic used by both
+    manual and cloud device setup flows.
+
+    Args:
+        serial_number: Device serial number (required)
+        discovery_method: How device was discovered (required)
+        device_name: Human-readable device name
+        hostname: Device IP/hostname for local connection
+        credential: Device credential for MQTT
+        mqtt_prefix: MQTT topic prefix
+        device_category: Device category (normalized to list)
+        capabilities: Device capabilities (normalized to list)
+        connection_type: Connection preference
+        username: Cloud username/email
+        auth_token: Cloud authentication token
+        product_type: Product type from cloud
+        category: Raw category from cloud (for compatibility)
+        parent_entry_id: Link to parent account entry
+        **kwargs: Additional fields to include
+
+    Returns:
+        Dictionary of config entry data
+    """
+    # Start with required fields
+    config_data = {
+        CONF_SERIAL_NUMBER: serial_number,
+        CONF_DISCOVERY_METHOD: discovery_method,
+    }
+
+    # Add optional fields if provided
+    if device_name:
+        config_data["device_name"] = device_name
+
+    if hostname:
+        config_data[CONF_HOSTNAME] = hostname
+
+    if credential:
+        config_data[CONF_CREDENTIAL] = credential
+
+    if mqtt_prefix:
+        config_data[CONF_MQTT_PREFIX] = mqtt_prefix
+
+    if connection_type:
+        config_data["connection_type"] = connection_type
+
+    if username:
+        config_data[CONF_USERNAME] = username
+
+    if auth_token:
+        config_data["auth_token"] = auth_token
+
+    if product_type:
+        config_data["product_type"] = product_type
+
+    if category:
+        config_data["category"] = category
+
+    if parent_entry_id:
+        config_data["parent_entry_id"] = parent_entry_id
+
+    # Normalize and add device category
+    config_data["device_category"] = normalize_device_category(device_category)
+
+    # Normalize and add capabilities
+    config_data["capabilities"] = normalize_capabilities(capabilities)
+
+    # Add any additional fields
+    config_data.update(kwargs)
+
+    return config_data
+
+
+def create_manual_device_config(
+    serial_number: str,
+    credential: str,
+    mqtt_prefix: str,
+    device_name: Optional[str] = None,
+    hostname: Optional[str] = None,
+    device_category: Optional[Any] = None,
+    capabilities: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Create config data for manually configured device.
+
+    Args:
+        serial_number: Device serial number
+        credential: Device WiFi credential
+        mqtt_prefix: MQTT topic prefix
+        device_name: Human-readable device name
+        hostname: Device IP/hostname
+        device_category: Device category
+        capabilities: Device capabilities
+
+    Returns:
+        Dictionary of config entry data for manual device
+    """
+    return create_device_config_data(
+        serial_number=serial_number,
+        discovery_method=DISCOVERY_MANUAL,
+        device_name=device_name or f"Dyson {serial_number}",
+        hostname=hostname,
+        credential=credential,
+        mqtt_prefix=mqtt_prefix,
+        device_category=device_category or ["ec"],
+        capabilities=capabilities or [],
+        connection_type=CONNECTION_TYPE_LOCAL_ONLY,  # Default for manual
+    )
+
+
+def create_cloud_device_config(
+    serial_number: str,
+    username: str,
+    device_info: Dict[str, Any],
+    auth_token: Optional[str] = None,
+    parent_entry_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create config data for cloud-discovered device.
+
+    Args:
+        serial_number: Device serial number
+        username: Cloud account username/email
+        device_info: Device information from cloud API
+        auth_token: Authentication token
+        parent_entry_id: Parent account entry ID
+
+    Returns:
+        Dictionary of config entry data for cloud device
+    """
+    return create_device_config_data(
+        serial_number=serial_number,
+        discovery_method=DISCOVERY_CLOUD,
+        device_name=device_info.get("name"),
+        username=username,
+        auth_token=auth_token,
+        product_type=device_info.get("product_type"),
+        category=device_info.get("category"),
+        device_category=device_info.get("category"),
+        capabilities=[],  # Will be extracted during coordinator setup
+        parent_entry_id=parent_entry_id,
+    )

--- a/custom_components/dyson_alt/number.py
+++ b/custom_components/dyson_alt/number.py
@@ -59,7 +59,7 @@ class DysonSleepTimerNumber(DysonEntity, NumberEntity):
         """Initialize the sleep timer number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_sleep_timer"
-        self._attr_name = "Sleep Timer"
+        self._attr_name = f"{coordinator.device_name} Sleep Timer"
         self._attr_icon = "mdi:timer"
         self._attr_mode = NumberMode.BOX
         self._attr_native_min_value = 0
@@ -109,7 +109,7 @@ class DysonOscillationLowerAngleNumber(DysonEntity, NumberEntity):
         """Initialize the oscillation lower angle number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_oscillation_lower_angle"
-        self._attr_name = "Oscillation Low Angle"
+        self._attr_name = f"{coordinator.device_name} Oscillation Low Angle"
         self._attr_icon = "mdi:rotate-left"
         self._attr_mode = NumberMode.SLIDER
         self._attr_native_min_value = 0
@@ -162,7 +162,7 @@ class DysonOscillationUpperAngleNumber(DysonEntity, NumberEntity):
         """Initialize the oscillation upper angle number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_oscillation_upper_angle"
-        self._attr_name = "Oscillation High Angle"
+        self._attr_name = f"{coordinator.device_name} Oscillation High Angle"
         self._attr_icon = "mdi:rotate-right"
         self._attr_mode = NumberMode.SLIDER
         self._attr_native_min_value = 0
@@ -215,7 +215,7 @@ class DysonOscillationCenterAngleNumber(DysonEntity, NumberEntity):
         """Initialize the oscillation center angle number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_oscillation_center_angle"
-        self._attr_name = "Oscillation Center Angle"
+        self._attr_name = f"{coordinator.device_name} Oscillation Center Angle"
         self._attr_icon = "mdi:crosshairs"
         self._attr_mode = NumberMode.SLIDER
         self._attr_native_min_value = 0
@@ -290,7 +290,7 @@ class DysonOscillationAngleSpanNumber(DysonEntity, NumberEntity):
         """Initialize the oscillation angle span number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_oscillation_angle_span"
-        self._attr_name = "Oscillation Angle Span"
+        self._attr_name = f"{coordinator.device_name} Oscillation Custom Angle"
         self._attr_icon = "mdi:angle-acute"
         self._attr_mode = NumberMode.SLIDER
         self._attr_native_min_value = 10
@@ -366,7 +366,7 @@ class DysonOscillationAngleNumber(DysonEntity, NumberEntity):
         """Initialize the oscillation angle number."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_oscillation_angle"
-        self._attr_name = "Oscillation Custom Angle"
+        self._attr_name = f"{coordinator.device_name} Oscillation Angle"
         self._attr_icon = "mdi:rotate-3d-variant"
         self._attr_mode = NumberMode.SLIDER
         self._attr_native_min_value = 45

--- a/custom_components/dyson_alt/select.py
+++ b/custom_components/dyson_alt/select.py
@@ -26,8 +26,7 @@ async def async_setup_entry(
 
     entities = []
 
-    # Fan control mode selection for all devices
-    entities.append(DysonFanControlModeSelect(coordinator))
+    # Fan control mode moved to fan platform preset modes
 
     # Add additional selects based on capabilities - temporarily enable all for testing
     device_capabilities = coordinator.device_capabilities
@@ -51,7 +50,7 @@ class DysonFanControlModeSelect(DysonEntity, SelectEntity):
         """Initialize the fan control mode select."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_fan_control_mode"
-        self._attr_name = "Fan Control Mode"
+        self._attr_name = f"{coordinator.device_name} Fan Control Mode"
         self._attr_icon = "mdi:fan-auto"
 
         # For manual devices, only show Auto and Manual (no Sleep)
@@ -119,7 +118,7 @@ class DysonOscillationModeSelect(DysonEntity, SelectEntity):
         """Initialize the oscillation mode select."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_oscillation_mode"
-        self._attr_name = "Oscillation"  # Renamed from "Oscillation Mode"
+        self._attr_name = f"{coordinator.device_name} Oscillation"  # Renamed from "Oscillation Mode"
         self._attr_icon = "mdi:rotate-3d-variant"
         self._attr_options = ["Off", "45°", "90°", "180°", "350°", "Custom"]
         # Hybrid approach: event-driven + state-based center preservation
@@ -404,7 +403,7 @@ class DysonHeatingModeSelect(DysonEntity, SelectEntity):
         """Initialize the heating mode select."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_heating_mode"
-        self._attr_name = "Heating Mode"
+        self._attr_name = f"{coordinator.device_name} Heating Mode"
         self._attr_icon = "mdi:radiator"
         self._attr_options = ["Off", "Heating", "Auto Heat"]
 

--- a/custom_components/dyson_alt/sensor.py
+++ b/custom_components/dyson_alt/sensor.py
@@ -82,7 +82,7 @@ class DysonFilterLifeSensor(DysonEntity, SensorEntity):
 
         self.filter_type = filter_type
         self._attr_unique_id = f"{coordinator.serial_number}_{filter_type}_filter_life"
-        self._attr_name = f"{filter_type.upper()} Filter Life"
+        self._attr_name = f"{coordinator.device_name} {filter_type.upper()} Filter Life"
         self._attr_native_unit_of_measurement = PERCENTAGE
         # No device class - filter life sensors don't have a specific Home Assistant device class
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -155,7 +155,7 @@ class DysonTemperatureSensor(DysonEntity, SensorEntity):
         super().__init__(coordinator)
 
         self._attr_unique_id = f"{coordinator.serial_number}_temperature"
-        self._attr_name = "Temperature"
+        self._attr_name = f"{coordinator.device_name} Temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "°C"
@@ -225,7 +225,7 @@ class DysonPM25Sensor(DysonEntity, SensorEntity):
         super().__init__(coordinator)
 
         self._attr_unique_id = f"{coordinator.serial_number}_pm25"
-        self._attr_name = "PM2.5"
+        self._attr_name = f"{coordinator.device_name} PM2.5"
         self._attr_device_class = SensorDeviceClass.PM25
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
@@ -285,7 +285,7 @@ class DysonPM10Sensor(DysonEntity, SensorEntity):
         super().__init__(coordinator)
 
         self._attr_unique_id = f"{coordinator.serial_number}_pm10"
-        self._attr_name = "PM10"
+        self._attr_name = f"{coordinator.device_name} PM10"
         self._attr_device_class = SensorDeviceClass.PM10
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
@@ -345,7 +345,7 @@ class DysonWiFiSensor(DysonEntity, SensorEntity):
         super().__init__(coordinator)
 
         self._attr_unique_id = f"{coordinator.serial_number}_wifi"
-        self._attr_name = "WiFi Signal"
+        self._attr_name = f"{coordinator.device_name} WiFi Signal"
         self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "dBm"
@@ -373,7 +373,7 @@ class DysonHEPAFilterLifeSensor(DysonEntity, SensorEntity):
         super().__init__(coordinator)
 
         self._attr_unique_id = f"{coordinator.serial_number}_hepa_filter_life"
-        self._attr_name = "HEPA Filter Life"
+        self._attr_name = f"{coordinator.device_name} HEPA Filter Life"
         self._attr_native_unit_of_measurement = PERCENTAGE
         # No device class - filter life sensors don't have a specific Home Assistant device class
         self._attr_state_class = SensorStateClass.MEASUREMENT
@@ -453,7 +453,7 @@ class DysonHEPAFilterTypeSensor(DysonEntity, SensorEntity):
         super().__init__(coordinator)
 
         self._attr_unique_id = f"{coordinator.serial_number}_hepa_filter_type"
-        self._attr_name = "HEPA Filter Type"
+        self._attr_name = f"{coordinator.device_name} HEPA Filter Type"
         self._attr_icon = "mdi:air-filter"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -524,7 +524,7 @@ class DysonConnectionStatusSensor(DysonEntity, SensorEntity):
         """Initialize the connection status sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_connection_status"
-        self._attr_name = "Connection Status"
+        self._attr_name = f"{coordinator.device_name} Connection Status"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_icon = "mdi:connection"
         self._attr_device_class = None

--- a/custom_components/dyson_alt/switch.py
+++ b/custom_components/dyson_alt/switch.py
@@ -29,10 +29,7 @@ async def async_setup_entry(
     # Basic switches for all devices
     entities.append(DysonNightModeSwitch(coordinator))
 
-    # Only add auto mode switch for cloud devices (not manual local-only devices)
-    connection_type = config_entry.data.get("connection_type", "unknown")
-    if connection_type != "local_only":
-        entities.append(DysonAutoModeSwitch(coordinator))
+    # Auto mode switch removed - now handled by fan platform preset modes
 
     # Add additional switches based on capabilities
     device_capabilities = coordinator.device_capabilities
@@ -59,7 +56,7 @@ class DysonAutoModeSwitch(DysonEntity, SwitchEntity):
         """Initialize the auto mode switch."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_auto_mode"
-        self._attr_name = "Auto Mode"
+        self._attr_name = f"{coordinator.device_name} Auto Mode"
         self._attr_icon = "mdi:auto-mode"
 
     def _handle_coordinator_update(self) -> None:
@@ -107,7 +104,7 @@ class DysonNightModeSwitch(DysonEntity, SwitchEntity):
         """Initialize the night mode switch."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_night_mode"
-        self._attr_name = "Night Mode"
+        self._attr_name = f"{coordinator.device_name} Night Mode"
         self._attr_icon = "mdi:weather-night"
 
     def _handle_coordinator_update(self) -> None:
@@ -155,7 +152,7 @@ class DysonOscillationSwitch(DysonEntity, SwitchEntity):
         """Initialize the oscillation switch."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_oscillation"
-        self._attr_name = "Oscillation"
+        self._attr_name = f"{coordinator.device_name} Oscillation"
         self._attr_icon = "mdi:rotate-3d-variant"
 
     def _handle_coordinator_update(self) -> None:
@@ -203,7 +200,7 @@ class DysonHeatingSwitch(DysonEntity, SwitchEntity):
         """Initialize the heating switch."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_heating"
-        self._attr_name = "Heating"
+        self._attr_name = f"{coordinator.device_name} Heating"
         self._attr_icon = "mdi:radiator"
 
     def _handle_coordinator_update(self) -> None:
@@ -249,7 +246,7 @@ class DysonContinuousMonitoringSwitch(DysonEntity, SwitchEntity):
         """Initialize the continuous monitoring switch."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.serial_number}_continuous_monitoring"
-        self._attr_name = "Continuous Monitoring"
+        self._attr_name = f"{coordinator.device_name} Continuous Monitoring"
         self._attr_icon = "mdi:monitor-eye"
 
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
Address multiple UAT feedback issues:

**Fan State Synchronization:**
- Add explicit is_on property override in fan.py to prevent FanEntity
  base class from overriding state based on percentage
- Fix issue where fan showed ON in UI despite device being OFF
- Enhanced debug logging for fan state transitions

**MQTT Polling Optimization:**
- Reduce device polling from 60s to 5min (connectivity checks only)
- Remove aggressive REQUEST-CURRENT-STATE polling during normal operation
- Rely primarily on natural STATE-CHANGE messages from device
- Only request current state after reconnection for initial sync
- Significantly reduced MQTT traffic and improved responsiveness

**ExtendedAQ Capability Support:**
- Fix enum value extraction in device_utils.normalize_capabilities()
- Use cap.value instead of str(cap) for proper enum handling
- Ensures cloud devices with ExtendedAQ capability get proper fault sensors
- Add enhanced debug logging for capability processing

**EnvironmentalData Capability:**
- Update capability description to clarify it's a meta-capability
- Change from 'Environmental Data (temperature, humidity sensors)'
  to 'Environmental Data (meta-capability, no specific sensors created)'

**Technical Improvements:**
- Add comprehensive device_utils.py for cloud device data normalization
- Enhanced coordinator message handling and debug logging
- Improved error handling and state management
- Better separation of concerns between polling and natural updates

Fixes fan state desynchronization, reduces device stress, and improves
overall integration reliability and performance.